### PR TITLE
Makefile.builder: restrict build for BACKEND_VMM=xen

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -1,3 +1,4 @@
+ifeq ($(BACKEND_VMM),xen)
 RPM_SPEC_FILES := rpm_spec/libvchan.spec
 ARCH_BUILD_DIRS := archlinux
 
@@ -15,4 +16,5 @@ ifeq ($(PACKAGE_SET),vm)
   WIN_SLN_DIR = vs2017
 endif
 
+endif
 # vim: filetype=make


### PR DESCRIPTION
QubesOS/qubes-issues#7051