### PR TITLE
Avoid using reserved identifiers in macros

### DIFF
--- a/vchan/libvchan.h
+++ b/vchan/libvchan.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef _LIBVCHAN_H
-#define _LIBVCHAN_H
+#ifndef LIBVCHAN_H
+#define LIBVCHAN_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -59,4 +59,4 @@ int libvchan_data_ready(libvchan_t *ctrl);
 int libvchan_buffer_space(libvchan_t *ctrl);
 void libvchan_set_blocking(libvchan_t *ctrl, bool blocking);
 
-#endif /* _LIBVCHAN_H */
+#endif /* LIBVCHAN_H */

--- a/vchan/libvchan_private.h
+++ b/vchan/libvchan_private.h
@@ -19,8 +19,8 @@
  *
  */
 
-#ifndef _LIBVCHAN_PRIVATE_H
-#define _LIBVCHAN_PRIVATE_H
+#ifndef LIBVCHAN_PRIVATE_H
+#define LIBVCHAN_PRIVATE_H
 
 #include <libxenvchan.h>
 


### PR DESCRIPTION
Fixes a clang warning.