### PR TITLE
Interface for async client connection

### DIFF
--- a/vchan/init.c
+++ b/vchan/init.c
@@ -23,8 +23,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <poll.h>
 #include <xenstore.h>
 #include <xenctrl.h>
+#include <assert.h>
 #include "libvchan.h"
 #include "libvchan_private.h"
 
@@ -68,16 +70,10 @@ err_asprintf:
     return NULL;
 }
 
-libvchan_t *libvchan_client_init(int domain, int port) {
-    char xs_path[255];
-    char xs_path_watch[255];
+libvchan_t *libvchan_client_init_async(int domain, int port, int *watch_fd) {
     libvchan_t *ctrl;
     xc_interface *xc_handle;
     struct xs_handle *xs;
-    char **vec;
-    unsigned int count, len;
-    char *dummy = NULL;
-    char *own_domid = NULL;
 
     if (domain < 0 || (unsigned)domain >= DOMID_FIRST_RESERVED) {
         fprintf(stderr, "Invalid peer domain ID %d\n", domain);
@@ -102,8 +98,6 @@ libvchan_t *libvchan_client_init(int domain, int port) {
         goto err_xc;
     }
 
-    len = 0;
-
     if (!xs_watch(xs, "domid", "domid")) {
         fprintf(stderr, "Cannot setup xenstore watch\n");
         goto err_xs;
@@ -112,89 +106,22 @@ libvchan_t *libvchan_client_init(int domain, int port) {
         fprintf(stderr, "Cannot setup xenstore watch\n");
         goto err_xs;
     }
-    while (!dummy || !len) {
-        vec = xs_read_watch(xs, &count);
-        if (vec) {
-            if (strcmp(vec[XS_WATCH_TOKEN], "domid") == 0) {
-                /* domid have changed */
-                if (own_domid) {
-                    free(own_domid);
-                    own_domid = NULL;
-                    xs_unwatch(xs, xs_path_watch, xs_path_watch);
-                }
-            }
-            free(vec);
-        }
-        if (!own_domid) {
-            int v;
 
-            /* construct xenstore path on first iteration and on every domid
-             * change detected (save+restore case) */
-            own_domid = xs_read(xs, 0, "domid", &len);
-            if (!own_domid) {
-                fprintf(stderr, "Cannot get own domid\n");
-                goto err_xs;
-            }
-            int own_domid_num = parse_domid(own_domid);
-            if (own_domid_num == DOMID_INVALID) {
-                fprintf(stderr, "Invalid own domid %s\n", own_domid);
-                free(own_domid);
-                goto err_xs;
-            }
-            if (own_domid_num == domain) {
-                fprintf(stderr, "Loopback vchan connection not supported\n");
-                free(own_domid);
-                goto err_xs;
-            }
-
-            v = snprintf(xs_path, sizeof(xs_path), "/local/domain/%d/data/vchan/%s/%d",
-                         domain, own_domid, port);
-            if ((unsigned)v >= sizeof(xs_path)) {
-                free(own_domid);
-                goto err_xs;
-            }
-            /* watch on this key as we might not have access to the whole directory */
-            v = snprintf(xs_path_watch, sizeof(xs_path_watch), "%.128s/event-channel", xs_path);
-            if ((unsigned)v >= sizeof(xs_path_watch)) {
-                free(own_domid);
-                goto err_xs;
-            }
-
-            if (!xs_watch(xs, xs_path_watch, xs_path_watch)) {
-                fprintf(stderr, "Cannot setup watch on %s\n", xs_path_watch);
-                free(own_domid);
-                goto err_xs;
-            }
-        }
-
-        dummy = xs_read(xs, 0, xs_path_watch, &len);
-        if (dummy)
-            free(dummy);
-        else {
-            if (!libvchan__check_domain_alive(xc_handle, domain)) {
-                fprintf(stderr, "domain dead\n");
-                goto err_xs;
-            }
-        }
-    }
-
-    free(own_domid);
-    xs_close(xs);
-
-    ctrl = malloc(sizeof(*ctrl));
+    ctrl = calloc(1, sizeof(*ctrl));
     if (!ctrl)
-        goto err_xc;
-    ctrl->xs_path = NULL;
-    ctrl->xenvchan = libxenvchan_client_init(NULL, domain, xs_path);
-    if (!ctrl->xenvchan) {
-        free(ctrl);
-        goto err_xc;
-    }
-    ctrl->xenvchan->blocking = 1;
-    /* notify server */
-    xc_evtchn_notify(ctrl->xenvchan->event, ctrl->xenvchan->event_port);
-    ctrl->remote_domain = domain;
+        goto err_xs;
+    ctrl->xs = xs;
     ctrl->xc_handle = xc_handle;
+    ctrl->remote_domain = domain;
+    ctrl->local_domain = DOMID_INVALID;
+    ctrl->port = port;
+
+    /*
+     * Watch for the path is established only when domid watch gets fired for
+     * the first time
+     */
+    *watch_fd = xs_fileno(xs);
+
     return ctrl;
 
 err_xs:
@@ -203,4 +130,154 @@ err_xc:
     xc_interface_close(xc_handle);
 err:
     return NULL;
+}
+
+int libvchan_client_init_async_finish(libvchan_t *ctrl, bool blocking) {
+    char xs_path_base[255];
+    char *own_domid;
+    char **vec;
+    unsigned int len;
+    char *tmp_str = NULL;
+
+    for (;;) {
+        vec = xs_check_watch(ctrl->xs);
+        if (vec) {
+            if (strcmp(vec[XS_WATCH_TOKEN], "domid") == 0) {
+                /* domid have changed */
+                if (ctrl->xs_path) {
+                    xs_unwatch(ctrl->xs, ctrl->xs_path, ctrl->xs_path);
+                    free(ctrl->xs_path);
+                    ctrl->xs_path = NULL;
+                }
+                ctrl->local_domain = DOMID_INVALID;
+            }
+            free(vec);
+        } else if (errno == EAGAIN) {
+            break;
+        } else if (errno == EINTR) {
+            continue;
+        } else {
+            return -1;
+        }
+    }
+
+    /* get local domid after watch gets registered, and after each change */
+    if (ctrl->local_domain == DOMID_INVALID) {
+        own_domid = xs_read(ctrl->xs, 0, "domid", &len);
+        if (!own_domid) {
+            fprintf(stderr, "Cannot get own domid\n");
+            goto err;
+        }
+        int own_domid_num = parse_domid(own_domid);
+        free(own_domid);
+        if (own_domid_num == DOMID_INVALID) {
+            fprintf(stderr, "Invalid own domid %s\n", own_domid);
+            goto err;
+        }
+        if (own_domid_num == ctrl->remote_domain) {
+            fprintf(stderr, "Loopback vchan connection not supported\n");
+            goto err;
+        }
+        ctrl->local_domain = own_domid_num;
+    }
+
+    /* construct xenstore path on first iteration and on every domid
+     * change detected (save+restore case) */
+    if (!ctrl->xs_path) {
+        int v;
+
+        v = snprintf(xs_path_base, sizeof(xs_path_base), "/local/domain/%d/data/vchan/%d/%d",
+                     ctrl->remote_domain, ctrl->local_domain, ctrl->port);
+        if ((unsigned)v >= sizeof(xs_path_base)) {
+            goto err;
+        }
+
+        /* watch on this key as we might not have access to the whole directory */
+        v = asprintf(&ctrl->xs_path, "%.128s/event-channel", xs_path_base);
+        if (v < 0) {
+            goto err;
+        }
+
+        if (!xs_watch(ctrl->xs, ctrl->xs_path, ctrl->xs_path)) {
+            fprintf(stderr, "Cannot setup watch on %s\n", ctrl->xs_path);
+            goto err;
+        }
+    }
+
+    tmp_str = xs_read(ctrl->xs, 0, ctrl->xs_path, &len);
+    if (tmp_str)
+        free(tmp_str);
+    else {
+        if (!libvchan__check_domain_alive(ctrl->xc_handle, ctrl->remote_domain)) {
+            fprintf(stderr, "domain dead\n");
+            goto err;
+        }
+        /* no xenstore entry (yet), wait more */
+        return 1;
+    }
+
+    if (!len) {
+        /* empty entry, wait more */
+        return 1;
+    }
+
+    /* when got here, wait is over, attempt to connect */
+    xs_close(ctrl->xs);
+    ctrl->xs = NULL;
+
+    /* cut trailing /event-channel */
+    tmp_str = strrchr(ctrl->xs_path, '/');
+    assert(tmp_str);
+    *tmp_str = '\0';
+
+    ctrl->xenvchan = libxenvchan_client_init(NULL, ctrl->remote_domain, ctrl->xs_path);
+    free(ctrl->xs_path);
+    ctrl->xs_path = NULL;
+    if (!ctrl->xenvchan)
+        goto err;
+    ctrl->xenvchan->blocking = blocking;
+    /* notify server */
+    xc_evtchn_notify(ctrl->xenvchan->event, ctrl->xenvchan->event_port);
+    return 0;
+
+err:
+    return -1;
+}
+
+libvchan_t *libvchan_client_init(int domain, int port) {
+    libvchan_t *ctrl;
+    int watch_fd, connect_ret = 1;
+    struct pollfd vchan_wait = {
+        .events = POLLIN,
+    };
+
+    ctrl = libvchan_client_init_async(domain, port, &watch_fd);
+    if (!ctrl)
+        return NULL;
+
+    vchan_wait.fd = watch_fd;
+    do {
+        if (poll(&vchan_wait, 1, -1) == -1 && errno != EINTR) {
+            perror("poll");
+            libvchan_close(ctrl);
+            return NULL;
+        }
+        if (vchan_wait.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+            fprintf(stderr, "unexpected watch_fd event: 0x%x\n", vchan_wait.revents);
+            libvchan_close(ctrl);
+            return NULL;
+        }
+        if (vchan_wait.revents & POLLIN) {
+            connect_ret = libvchan_client_init_async_finish(ctrl, true);
+        }
+    } while (connect_ret > 0);
+
+    if (connect_ret < 0) {
+        /* error, ctrl already cleaned up */
+        return NULL;
+    }
+
+    assert(connect_ret == 0);
+    /* connected */
+    return ctrl;
 }

--- a/vchan/io.c
+++ b/vchan/io.c
@@ -173,8 +173,8 @@ void libvchan_close(libvchan_t *ctrl) {
     struct xs_handle *xs;
 
     libxenvchan_close(ctrl->xenvchan);
-    if (ctrl->xs_path) {
-        /* remove xenstore entry in case of no client connected */
+    if (ctrl->xenvchan && ctrl->xs_path) {
+        /* remove server xenstore entry in case of no client connected */
         xs = xs_open(0);
         if (xs) {
             /* if xenstore connection failed just do not remove entries, but do
@@ -185,6 +185,9 @@ void libvchan_close(libvchan_t *ctrl) {
         }
         free(ctrl->xs_path);
     }
+    /* this releases watches too */
+    if (ctrl->xs)
+        xs_close(ctrl->xs);
     if (ctrl->xc_handle)
         xc_interface_close(ctrl->xc_handle);
     free(ctrl);

--- a/vchan/libvchan.h
+++ b/vchan/libvchan.h
@@ -37,7 +37,7 @@ typedef int EVTCHN;
 #define VCHAN_DISCONNECTED 0
 /* connected */
 #define VCHAN_CONNECTED 1
-/* vchan server initialized, waiting for client to connect */
+/* vchan initialized, waiting for client to connect, or server to appear */
 #define VCHAN_WAITING 2
 
 struct libvchan;
@@ -71,6 +71,10 @@ int libvchan_is_open(libvchan_t *ctrl);
 
 int libvchan_data_ready(libvchan_t *ctrl);
 int libvchan_buffer_space(libvchan_t *ctrl);
+/* Must be called only after successful libvchan_*_init(). When using
+ * libvchan_client_init_async(), prefer using blocking parameter to
+ * libvchan_client_init_async_finish() instead.
+ */
 void libvchan_set_blocking(libvchan_t *ctrl, bool blocking);
 
 #endif /* LIBVCHAN_H */

--- a/vchan/libvchan.h
+++ b/vchan/libvchan.h
@@ -47,6 +47,19 @@ libvchan_t *libvchan_server_init(int domain, int port, size_t read_min, size_t w
 
 libvchan_t *libvchan_client_init(int domain, int port);
 
+/* An alternative path for client connection:
+ * 1. Call libvchan_client_init_async().
+ * 2. Wait for watch_fd to become readable.
+ * 3. When readable, call libvchan_client_init_async_finish().
+ *
+ * Repeat steps 2-3 until libvchan_client_init_async_finish returns 0. Abort on
+ * negative values (error).
+ * If connection attempt failed or should be aborted, call libvchan_close() to
+ * clean up.
+ */
+libvchan_t *libvchan_client_init_async(int domain, int port, EVTCHN *watch_fd);
+int libvchan_client_init_async_finish(libvchan_t *ctrl, bool blocking);
+
 int libvchan_write(libvchan_t *ctrl, const void *data, size_t size);
 int libvchan_send(libvchan_t *ctrl, const void *data, size_t size);
 int libvchan_read(libvchan_t *ctrl, void *data, size_t size);

--- a/vchan/libvchan_private.h
+++ b/vchan/libvchan_private.h
@@ -26,10 +26,16 @@
 
 struct libvchan {
     struct libxenvchan *xenvchan;
-    /* store path, which should be removed after client connect (server only) */
+    /*
+     * server: path to be removed when client connects,
+     * client: path currently watched, for async init
+     */
     char *xs_path;
     int remote_domain;
+    int local_domain;
+    int port;
     xc_interface *xc_handle;
+    struct xs_handle *xs;
 };
 
 int libvchan__check_domain_alive(xc_interface *xc_handle, int dom);

--- a/windows/include/libvchan.h
+++ b/windows/include/libvchan.h
@@ -103,6 +103,18 @@ int libvchan_data_ready(libvchan_t *ctrl);
 LIBVCHAN_API
 int libvchan_buffer_space(libvchan_t *ctrl);
 
+/* TODO:
+
+LIBVCHAN_API
+libvchan_t *libvchan_client_init_async(int domain, int port, EVTCHN *watch_fd);
+
+LIBVCHAN_API
+int libvchan_client_init_async_finish(libvchan_t *ctrl);
+
+LIBVCHAN_API
+void libvchan_client_init_async_cancel(libvchan_t *ctrl);
+*/
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Currently only server connection can be established asynchronously. This
commit introduces proposed API for async client connection too.

Implementation-wise, the libvchan_client_init() consists mostly of
waiting-for-server code, and then calling libxenvchan_client_init().
libxenvchan_client_init() normally exits with an error if server is not
running yet. The idea is to split libvchan_client_init() into separate
functions that do not wait on its own, but delegate it to the
application as waiting for an FD to become readable (which will in
practice be waiting for a xenstore watch).

This commit contains just proposed interface for now.

Related to QubesOS/qubes-issues#7964