### PR TITLE
Support changed libxenctrl API in Xen 4.18.0

### DIFF
--- a/vchan/Makefile.linux
+++ b/vchan/Makefile.linux
@@ -27,6 +27,10 @@ CFLAGS += -g -Wall -Wextra -Werror -fPIC -O2 -D_GNU_SOURCE -MD -MP -MF $@.dep
 all: libvchan-xen.so vchan-xen.pc
 -include *.dep
 
+# xenctrl.h does not provide any #define to distinguish API versions
+XENCTRL_VERSION := $(shell pkg-config --modversion xencontrol)
+CFLAGS += $(shell if printf '%s\n' '4.18.0' '$(XENCTRL_VERSION)' | \
+                  sort -CV; then echo -DHAVE_XC_DOMAIN_GETINFO_SINGLE; fi)
 SO_VER = 1
 
 libvchan-xen.so.$(SO_VER): init.o io.o

--- a/vchan/init.c
+++ b/vchan/init.c
@@ -47,7 +47,7 @@ static domid_t parse_domid(const char *ptr) {
 libvchan_t *libvchan_server_init(int domain, int port, size_t read_min, size_t write_min) {
     libvchan_t *ctrl;
 
-    ctrl = calloc(sizeof(*ctrl), 1);
+    ctrl = calloc(1, sizeof(*ctrl));
     if (!ctrl)
         return NULL;
 


### PR DESCRIPTION
The xc_domain_getinfo() is gone, it's replaced with
xc_domain_getinfo_single. While the new API is a bit nicer, xenctrl.h
does not provide any #define to know which one is available. Check
library version in the makefile for that.