### PR TITLE
debian: require pkg-config

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,12 @@ Source: libvchan-xen
 Section: libs
 Priority: extra
 Maintainer: Jason Mehring <nrgaway@gmail.com>
-Build-Depends: debhelper, quilt, autotools-dev, libxen-dev
+Build-Depends:
+ debhelper,
+ quilt,
+ autotools-dev,
+ pkg-config,
+ libxen-dev
 Standards-Version: 3.9.5
 Homepage: http://www.qubes-os.org
 


### PR DESCRIPTION
It's used to check Xen libraries version - necessary to detect changed
API in Xen libs >= 4.18.

Fixes QubesOS/qubes-issues#9746