### PR TITLE
windows: fix local clean script & don't use local .artifacts dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/.artifacts/
 rpm/
 deb/
 *~

--- a/windows/clean.cmd
+++ b/windows/clean.cmd
@@ -1,4 +1,3 @@
-rd /s /q %~dp0\..\.artifacts
 rd /s /q %~dp0\vs2022\tmp
 rd /s /q %~dp0\vs2022\x64
 del /q /a /f %~dp0\sign.crt

--- a/windows/clean.cmd
+++ b/windows/clean.cmd
@@ -1,5 +1,5 @@
 rd /s /q %~dp0\..\.artifacts
 rd /s /q %~dp0\vs2022\tmp
 rd /s /q %~dp0\vs2022\x64
-del /s /q /f %~dp0\sign.crt
-del /s /q /f %~dp0\include\qwt_version.h
+del /q /a /f %~dp0\sign.crt
+del /q /a /f %~dp0\include\qwt_version.h


### PR DESCRIPTION
- Fix local clean script
- Don't use local `.artifacts` dir (https://github.com/QubesOS/qubes-builderv2/commit/09fad4b51b8f89a8f3a1b2ec6443e736b8b22337)